### PR TITLE
Null out the order by clause

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -286,6 +286,7 @@ class GoogleSitemap {
 
 				$lastEdited = $instances
 					->limit($countPerFile, ($i - 1) * $countPerFile)
+					->sort(array())
 					->max('LastEdited');
 
 				$lastModified = ($lastEdited) ? date('Y-m-d', strtotime($lastEdited)) : date('Y-m-d');


### PR DESCRIPTION
Fixes `SELECT DISTINCT MAX("LastEdited") FROM "SiteTree_Live" ORDER BY "SiteTree_Live"."Sort" ASC LIMIT 1000 | ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list` on Postgres