### PR TITLE
Allow URLs to be case insensitive

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -182,6 +182,15 @@ class GoogleSitemap {
 	 * @return ArrayList
 	 */
 	public static function get_items($class, $page = 1) {
+		//normalise the class name
+		try {
+			$reflectionClass = new ReflectionClass($class);
+			$class = $reflectionClass->getName();
+		} catch (ReflectionException $e) {
+			// this can happen when $class is GoogleSitemapRoute
+			//we should try to carry on
+		}
+
 		$output = new ArrayList();
 		$count = Config::inst()->get('GoogleSitemap', 'objects_per_sitemap');
 		$filter =  Config::inst()->get('GoogleSitemap', 'use_show_in_search');

--- a/tests/GoogleSitemapTest.php
+++ b/tests/GoogleSitemapTest.php
@@ -89,7 +89,7 @@ class GoogleSitemapTest extends FunctionalTest {
 
 		$expected = "<loc>". Director::absoluteURL("sitemap.xml/sitemap/GoogleSitemapTest_UnviewableDataObject/2") ."</loc>";
 		$this->assertEquals(0, substr_count($body, $expected) , 'A link to a GoogleSitemapTest_UnviewableDataObject does not exist');
-	} 
+	}
 
 	public function testLastModifiedDateOnRootXML() {
 		Config::inst()->update('GoogleSitemap', 'enabled', true);
@@ -154,6 +154,19 @@ class GoogleSitemapTest extends FunctionalTest {
 		GoogleSitemap::register_dataobject("GoogleSitemapTest_DataObject");
 
 		$response = $this->get('sitemap.xml/sitemap/GoogleSitemapTest_DataObject/1');
+		$body = $response->getBody();
+
+		$this->assertEquals(200, $response->getStatusCode(), 'successful loaded nested sitemap');
+
+		Config::inst()->update('GoogleSitemap', 'objects_per_sitemap', $original);
+	}
+
+	public function testAccessingNestedSiteMapCaseInsensitive() {
+		$original = Config::inst()->get('GoogleSitemap', 'objects_per_sitemap');
+		Config::inst()->update('GoogleSitemap', 'objects_per_sitemap', 1);
+		GoogleSitemap::register_dataobject("GoogleSitemapTest_DataObject");
+
+		$response = $this->get('sitemap.xml/sitemap/googlesitemaptest_dataobject/1');
 		$body = $response->getBody();
 
 		$this->assertEquals(200, $response->getStatusCode(), 'successful loaded nested sitemap');


### PR DESCRIPTION
At the moment, going to

http://example.com/sitemap.xml/sitetree/1

Will break and cause a 500 because the case of the class name in the URL is passed to the query builder.