### PR TITLE
FIX/NEW for #90 Allow ability to alter DataList and deprecate static interface for better extensibility.

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -204,7 +204,6 @@ class GoogleSitemap extends Object {
 		if($class == "SiteTree") {
 			$filter = ($filter) ? "\"ShowInSearch\" = 1" : "";
 			$instances = Versioned::get_by_stage('SiteTree', 'Live', $filter);
-			$this->extend("alterDataList", $instances, $class);
 		}
 		else if($class == "GoogleSitemapRoute") {
 			$instances = array_slice(self::$routes, ($page - 1) * $count, $count);
@@ -225,6 +224,8 @@ class GoogleSitemap extends Object {
 		else {
 			$instances = new DataList($class);
 		}
+
+		$this->extend("alterDataList", $instances, $class);
 
 		$instances = $instances->limit(
 			$count, 
@@ -341,7 +342,7 @@ class GoogleSitemap extends Object {
 			foreach(self::$dataobjects as $class => $config) {
 				$list = new DataList($class);
 				$list = $list->sort('LastEdited ASC');
-				
+				$this->extend("alterDataList", $list, $class);
 				$neededForClass = ceil($list->count() / $countPerFile);
 
 				for($i = 1; $i <= $neededForClass; $i++) {

--- a/code/controllers/GoogleSitemapController.php
+++ b/code/controllers/GoogleSitemapController.php
@@ -22,6 +22,7 @@ class GoogleSitemapController extends Controller {
 		'sitemap'	
 	);
 
+
 	/**
 	 * Default controller action for the sitemap.xml file. Renders a index
 	 * file containing a list of links to sub sitemaps containing the data.
@@ -35,7 +36,7 @@ class GoogleSitemapController extends Controller {
 			$this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');
 			$this->getResponse()->addHeader('X-Robots-Tag', 'noindex');
 
-			$sitemaps = GoogleSitemap::get_sitemaps();
+			$sitemaps = GoogleSitemap::inst()->getSitemaps();
 			$this->extend('updateGoogleSitemaps', $sitemaps);
 
 			return array(
@@ -62,7 +63,7 @@ class GoogleSitemapController extends Controller {
 			$this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');
 			$this->getResponse()->addHeader('X-Robots-Tag', 'noindex');
 
-			$items = GoogleSitemap::get_items($class, $page);
+			$items = GoogleSitemap::inst()->getItems($class, $page);
 			$this->extend('updateGoogleSitemapItems', $items, $class, $page);
 
 			return array(

--- a/tests/GoogleSitemapTest.php
+++ b/tests/GoogleSitemapTest.php
@@ -1,6 +1,8 @@
 <?php
 
 /**
+ * TODO: Migrate to new instance level interface instead of using static methods for retrieval of site maps and items (i.e. ->getSitemaps() instead of ::get_sitemaps()).
+ *
  * @package googlesitemaps
  * @subpackage tests
  */


### PR DESCRIPTION
Fix (or adding new functionality) for #90

I also did *some* minor touch up of return documentation and return values. In this case, I just setup an empty string return at the end of `get_frequency_for_class()`. I'd do more but that would be much more out of scope for this issue/PR plus I don't have much time to look into that.

Anyway, here's an example for how you'd make use of this feature:

**config.yaml**
```yaml
GoogleSitemap:
  extensions:
    - GoogleSitemapCustomExtension

```

**mysite/code/GoogleSitemapCustomExtension.php**
```php
<?php

class GoogleSitemapCustomExtension extends Extension {
	/**
	 * Ensure that only specific site domain ID's are allowed in GoogleSitemap module for front-end display. Note the use
	 * of &$dataList being passed by reference. This is because while the class itself is still a reference (by default)
	 * in PHP, we must actually modify the original variable that is referring to that variable. 
	 * 
	 * @param	DataList	$dataList
	 * @param	string	$class
	 */
	public function alterDataList(DataList &$dataList, $class) {
		if (strtolower($class) == "sitetree") {
			$dataList = $dataList->innerJoin("Page_Live", "Page_Live.ID=SiteTree_Live.ID");
			$dataList = $dataList->where("SiteDomainID=0 OR SiteDomainID=2");
		}
	}
}
```