### PR TITLE
FIX for #78 to workaround ->alterCanIncludeInGoogleSitemap() not working

### DIFF
--- a/code/extensions/GoogleSitemapExtension.php
+++ b/code/extensions/GoogleSitemapExtension.php
@@ -33,7 +33,13 @@ class GoogleSitemapExtension extends DataExtension
             $can = $this->owner->getGooglePriority();
         }
 
-        $this->owner->invokeWithExtensions('alterCanIncludeInGoogleSitemap', $can);
+        // Allow override. In this case, since this can return multiple results, we'll use an "and" based policy. That is
+        // if any value is false then the current value will be false. Only only if all are true will we then return true.
+        $override = $this->owner->invokeWithExtensions('alterCanIncludeInGoogleSitemap', $can);
+        if ($override) {
+            $can = min($override);
+        }
+
 
         return $can;
     }


### PR DESCRIPTION
Fixes #78. This is due to core bug with `->invokeWithExtensions()` not allowing references.  @tractorcow is already addressing a fix in that method (see here for details: https://github.com/silverstripe/silverstripe-framework/issues/3745#issuecomment-187941032), so in the meantime we can fix this here by simply using the return value instead of depending on the reference being updated. 

This should be _reasonably_ safe (but not 100%) since anyone using this will likely NOT be returning and modifying by reference does nothing anyway, so no loss, only gain. Only potential may be if someone is erroneously returning when they should be modifying by reference but, I hope that's unlikely :smile: 

**Question** for either @wilr or @tractorcow: Since we don't really know the developers intent (if/when they use this custom `->alterCanIncludeInGoogleSitemap()` method) should we just use the **last** return value (since one was now positively returned and technically now has intent to override). This is (almost) the same as modifying by reference, but not quite (since by reference, each additional call can look at the current value and decide to change it). However, due to issues with separation of concerns, there's no guarantee that each observer of that `->alterCanIncludeInGoogleSitemap()` method will conspire to "or" vs "and" the value (since it is just a boolean).

**Another question:** Since the concept of altering is effectively useless until `silverstripe-framework` v4 rolls around (with the fix being in master) will it make sense to tweak the name to not include the word "alter"?
