### PR TITLE
Exclude all Redirector templates, not just RedirectorPage

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -227,7 +227,9 @@ class GoogleSitemap extends Object
             }
 
             if($redirector) {
-                $instances = $instances->exclude('ClassName', 'RedirectorPage');
+                foreach (ClassInfo::subclassesFor('RedirectorPage') as $redirectorClass) {
+                    $instances = $instances->exclude('ClassName', $redirectorClass);
+                }
             }
         } elseif ($class == "GoogleSitemapRoute") {
             $instances = array_slice(self::$routes, ($page - 1) * $count, $count);


### PR DESCRIPTION
Classes that extend RedirectorPage are still included in the sitemap if exclude_redirector_pages is enabled. This change excludes all subclasses as well.