### PR TITLE
BUGFIX: Fixed issue where classes not in the sitemap would cause a crash

### DIFF
--- a/code/GoogleSitemap.php
+++ b/code/GoogleSitemap.php
@@ -118,7 +118,13 @@ class GoogleSitemap extends Object
      */
     public static function is_registered($className)
     {
-        return isset(self::$dataobjects[$className]);
+        if (!isset(self::$dataobjects[$className])) {
+            $lowerKeys = array_change_key_case(self::$dataobjects);
+            
+            return isset($lowerKeys[$className]);
+        }
+        
+        return true;
     }
 
     /**

--- a/code/controllers/GoogleSitemapController.php
+++ b/code/controllers/GoogleSitemapController.php
@@ -60,7 +60,7 @@ class GoogleSitemapController extends Controller
         $class = $this->unsanitiseClassName($this->request->param('ID'));
         $page = $this->request->param('OtherID');
 
-        if (GoogleSitemap::enabled() && $class && $page) {
+        if (GoogleSitemap::enabled() && $class && $page && ($class=='SiteTree' || GoogleSitemap::is_registered($class))) {
             Config::inst()->update('SSViewer', 'set_source_file_comments', false);
             
             $this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');

--- a/code/controllers/GoogleSitemapController.php
+++ b/code/controllers/GoogleSitemapController.php
@@ -60,7 +60,7 @@ class GoogleSitemapController extends Controller
         $class = $this->unsanitiseClassName($this->request->param('ID'));
         $page = $this->request->param('OtherID');
 
-        if (GoogleSitemap::enabled() && $class && $page && ($class=='SiteTree' || GoogleSitemap::is_registered($class))) {
+        if (GoogleSitemap::enabled() && $class && $page && ($class == 'SiteTree' || $class == 'GoogleSitemapRoute' || GoogleSitemap::is_registered($class))) {
             Config::inst()->update('SSViewer', 'set_source_file_comments', false);
             
             $this->getResponse()->addHeader('Content-Type', 'application/xml; charset="utf-8"');


### PR DESCRIPTION
When a class is not allowed in the sitemap a DataList is attempted to be created regardless whether it exists or is even allowed in the sitemap. If the class does not exist this results in a "Can't find data classes (classes linked to tables)" error. If the class is a DataObject his results in a "the method 'canincludeingooglesitemap' does not exist" error. This pull request checks to see if the class is allowed in the sitemap, if it does not a 404 is returned.